### PR TITLE
Add support for Thermals Blitz, Blizz and Basalz

### DIFF
--- a/assets/xaerominimap/entity/icon/definition/thermal/basalz.json
+++ b/assets/xaerominimap/entity/icon/definition/thermal/basalz.json
@@ -1,0 +1,21 @@
+{
+	"variants" : {
+		"default" : "model:0"
+	},
+	"modelConfigs" : [
+		{
+			"baseScale" : 0.9,
+			"rotationY" : 0,
+			"rotationX" : 0,
+			"rotationZ" : 0,
+			"offsetX" : 0,
+			"offsetY" : 0,
+			"modelMainPartFieldAliases" : [
+                "cofh.thermal.core.client.renderer.entity.model.BasalzModel;head"
+			],
+			"renderingFullModel" : false,
+			"modelPartsRotationReset" : false,
+			"layersAllowed" : true
+		}
+	]
+}

--- a/assets/xaerominimap/entity/icon/definition/thermal/blitz.json
+++ b/assets/xaerominimap/entity/icon/definition/thermal/blitz.json
@@ -1,0 +1,21 @@
+{
+	"variants" : {
+		"default" : "model:0"
+	},
+	"modelConfigs" : [
+		{
+			"baseScale" : 0.9,
+			"rotationY" : 0,
+			"rotationX" : 0,
+			"rotationZ" : 0,
+			"offsetX" : 0,
+			"offsetY" : 0,
+			"modelMainPartFieldAliases" : [
+                "cofh.thermal.core.client.renderer.entity.model.BlitzModel;head"
+			],
+			"renderingFullModel" : false,
+			"modelPartsRotationReset" : false,
+			"layersAllowed" : true
+		}
+	]
+}

--- a/assets/xaerominimap/entity/icon/definition/thermal/blizz.json
+++ b/assets/xaerominimap/entity/icon/definition/thermal/blizz.json
@@ -1,0 +1,21 @@
+{
+	"variants" : {
+		"default" : "model:0"
+	},
+	"modelConfigs" : [
+		{
+			"baseScale" : 0.9,
+			"rotationY" : 0,
+			"rotationX" : 0,
+			"rotationZ" : 0,
+			"offsetX" : 0,
+			"offsetY" : 0,
+			"modelMainPartFieldAliases" : [
+                "cofh.thermal.core.client.renderer.entity.model.BlizzModel;head"
+			],
+			"renderingFullModel" : false,
+			"modelPartsRotationReset" : false,
+			"layersAllowed" : true
+		}
+	]
+}

--- a/assets/xaerominimap/entity/icon/definition/thermal/blizz.json
+++ b/assets/xaerominimap/entity/icon/definition/thermal/blizz.json
@@ -4,7 +4,7 @@
 	},
 	"modelConfigs" : [
 		{
-			"baseScale" : 0.9,
+			"baseScale" : 1,
 			"rotationY" : 0,
 			"rotationX" : 0,
 			"rotationZ" : 0,


### PR DESCRIPTION
Copied from the existing file for Atums Bonestorm. Tested and works.

Also changes the icon when its angry (because their texture changes when angry). Just an interesting thing I noticed.
![image](https://user-images.githubusercontent.com/73862885/139970179-7d8288bc-d188-4fe7-b86d-373cf4999a81.png)
(The blaze for scale)
The icon sizes are approximately the same size as a blaze, however the Blitz and Basalz have odd head shapes so they are just... strange.